### PR TITLE
Cheap-wins from #19: clear 4 OR-version-locked tests, refine 3 rationales

### DIFF
--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapterIntegrationTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapterIntegrationTest.java
@@ -90,7 +90,10 @@ public class OpenRewriteNamedRecipeAdapterIntegrationTest {
     }
 
     @Test
-    @Disabled("FIXME: OR8.1")
+    @Disabled("Test asserts the visitor-error wrapper message ('A problem happened whilst visiting') "
+            + "is propagated as the root cause. Under OR 8.80.1 the recipe-name lookup fails first "
+            + "(ErrorClass isn't a real recipe in the registry), so the test never exercises the "
+            + "visit path. Needs a test-only recipe that loads but throws during visit. Tracked in #19.")
     public void propagateExceptionFromOpenRewriteRecipe() throws IOException {
 
         String actionDescription =

--- a/components/sbm-core/src/test/java/org/springframework/sbm/java/impl/OpenRewriteTypeTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/java/impl/OpenRewriteTypeTest.java
@@ -308,7 +308,8 @@ class OpenRewriteTypeTest {
                         return IntegrationFlows.from(Http.inboundChannelAdapter("/test")).handle((p, h) -> p)
                                 .log(LoggingHandler.Level.INFO)
                                 .get();
-                    }}"""
+                    }
+                }"""
         );
     }
 
@@ -384,7 +385,8 @@ class OpenRewriteTypeTest {
                         return IntegrationFlows.from(Http.inboundChannelAdapter("/test")).handle((p, h) -> p)
                                 .log(LoggingHandler.Level.INFO)
                                 .get();
-                    }}"""
+                    }
+                }"""
         );
     }
     
@@ -405,7 +407,8 @@ class OpenRewriteTypeTest {
                         return IntegrationFlows.from(Http.inboundChannelAdapter("/test")).handle((p, h) -> p)
                                 .log(LoggingHandler.Level.INFO)
                                 .get();
-                    }}""";
+                    }
+                }""";
 
         ProjectContext context = TestProjectContext.buildProjectContext()
                 .withBuildFileHavingDependencies(

--- a/components/sbm-core/src/test/java/org/springframework/sbm/project/buildfile/OpenRewriteMavenBuildFileTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/project/buildfile/OpenRewriteMavenBuildFileTest.java
@@ -381,7 +381,10 @@ public class OpenRewriteMavenBuildFileTest {
     */
     @Test
     @Tag("integration")
-    @Disabled("Disabled after upgrade to 7.25.0 because org/jboss/logging/jboss-logging/3.3.2.Final/jboss-logging-3.3.2.Final.jar is sometimes retreived and sometimes iot isn't")
+    @Disabled("Asserts on a hardcoded list of ~80 transitive jar paths from a fixture pom. "
+            + "Brittle to maven-central availability and to dependency-resolution changes; "
+            + "fails under OR 8.80.1 with a different set of resolved jars than the literal expects. "
+            + "Independent of OR version. Tracked in #19.")
     void testResolvedDependenciesWithPomTypeDependency() {
         String pomXml =
                 "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +

--- a/components/sbm-openrewrite/src/test/java/org/openrewrite/maven/spring/UpgradeUnmanagedSpringProjectTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/openrewrite/maven/spring/UpgradeUnmanagedSpringProjectTest.java
@@ -38,7 +38,10 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@Disabled("FIXME:  Disabled with Upgrade to OR 8.1.x. See comment in UpgradeUnmanagedSpringProject")
+@Disabled("DependencyVersionHelper.getLatestReleaseVersion (called from static initializer at line 43) "
+        + "throws ClassCastException 'String cannot be cast to JSONObject'. Independent of OR version. "
+        + "Pre-existing helper bug; needs DependencyVersionHelper to handle response shape changes. "
+        + "Tracked in #19.")
 public class UpgradeUnmanagedSpringProjectTest {
 
     private static final String METRICS_ANNOTATION_VERSION = DependencyVersionHelper.getLatestReleaseVersion("io.dropwizard.metrics", "metrics-annotation").get();

--- a/components/sbm-openrewrite/src/test/java/org/springframework/sbm/openrewrite/XmlParserTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/springframework/sbm/openrewrite/XmlParserTest.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 public class XmlParserTest {
 
     @Test
-    @Disabled("Fails in Rewrite 7.16.3")
     void parseXhtml() {
         String xml =
                 "<?xml version='1.0' encoding='UTF-8' ?>\n" +

--- a/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/xml/XmlParserTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/xml/XmlParserTest.java
@@ -36,7 +36,6 @@ public class XmlParserTest {
 
     @GitHubIssue("https://github.com/openrewrite/rewrite/issues/1259")
     @Test
-    @Disabled("Experienced in 7.16.3")
     void parseXhtml() {
         String xhtml =
                 "<?xml version='1.0' encoding='UTF-8' ?>\n" +


### PR DESCRIPTION
## Summary

First pass on the cheap-wins from issue #19 (post-PR #18 follow-up).

**+4 tests** moved from `@Disabled` / excluded → green:
- `OpenRewriteTypeTest#testAddMethod` and `#testAddMethod2` — fixture drift; OR 8.80.1 prints class-closing brace on its own line, literal had `}}`
- `org.springframework.sbm.openrewrite.XmlParserTest#parseXhtml` — "Fails in Rewrite 7.16.3" no longer reproduces on 8.80.1
- `org.springframework.sbm.support.openrewrite.xml.XmlParserTest#parseXhtml` — same root cause, same resolution

**Refined rationales** for 3 tests that initially looked OR-version-related but turned out independent. Each is now `@Disabled` with a precise explanation pointing back to #19:
- `OpenRewriteNamedRecipeAdapterIntegrationTest.propagateExceptionFromOpenRewriteRecipe` — recipe-name lookup now fails *before* visit, so the test never exercises the visitor-error path it asserts on. Needs a test-only recipe that loads but throws during visit.
- `UpgradeUnmanagedSpringProjectTest` (class-level) — static initializer calls `DependencyVersionHelper.getLatestReleaseVersion` which throws `ClassCastException 'String cannot be cast to JSONObject'`. Pre-existing helper bug, independent of OR.
- `OpenRewriteMavenBuildFileTest#testResolvedDependenciesWithPomTypeDependency` — asserts on a hardcoded list of ~80 transitive jar paths; brittle to Maven Central availability and dependency-resolution changes.

## Status

Active reactor (12 modules) — `mvn test` BUILD SUCCESS in 26 min, all green excluding the 3 documented sandbox-env failures. No regressions; +4 net green tests.

```
spring-boot-migrator ............................... SUCCESS
test-helper ........................................ SUCCESS
sbm-openrewrite .................................... SUCCESS
sbm-core ........................................... SUCCESS
recipe-test-support ................................ SUCCESS
sbm-support-boot ................................... SUCCESS
sbm-support-jee .................................... SUCCESS
sbm-support-weblogic ............................... SUCCESS
sbm-recipes-jee-to-boot ............................ SUCCESS
sbm-recipes-spring-cloud ........................... SUCCESS
sbm-recipes-boot-upgrade ........................... SUCCESS
sbm-recipes-spring-framework ....................... SUCCESS
sbm-recipes-mule-to-boot ........................... SUCCESS
jaxrs-recipes ...................................... SUCCESS
```

## Test plan

- [x] Targeted: `mvn -pl components/sbm-core test -Dtest='OpenRewriteTypeTest#testAddMethod,OpenRewriteTypeTest#testAddMethod2'` → 2/2 pass
- [x] Targeted: `mvn -pl components/sbm-openrewrite test -Dtest='*XmlParserTest#parseXhtml'` → 2/2 pass
- [x] Full reactor: `mvn test -fae -Dspring-javaformat.skip=true -Dtest='!GitSupportTest#addAllAndCommit,!PreconditionVerifierIntegrationTest#allChecksSucceed,!MigrateToSpringCloudConfigServerIntegrationTest#recipeTest' -Dsurefire.failIfNoSpecifiedTests=false` → BUILD SUCCESS, 26 min

## Stacks on

This PR is stacked on `claude/handover-follow-up-idznA` (PR #18, jaxrs-recipes activation). Will rebase onto whatever `main`/`#16` ends up being once PR #18 lands.

Closes part of #19.

---
🤖 Generated by [Claude Code](https://claude.ai/code/session_01AqHuMPgEe25rTUm6Mb3Hvv)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqHuMPgEe25rTUm6Mb3Hvv)_